### PR TITLE
Replaced CB trigger for policy-lib population

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,13 @@ variable "policy_lib_cb_job_config" {
   default     = "cloudbuild-populate-policy-lib.yaml"
 }
 
-variable "org_repo_deploy_org_trigger_branch" {
+variable "org_repo_plan_org_trigger_branch" {
+  type        = string
+  description = "Org phase Cloud Source Repository branch name to trigger Cloud Build job to deploy org resources"
+  default     = "org-plan"
+}
+
+variable "org_repo_apply_org_trigger_branch" {
   type        = string
   description = "Org phase Cloud Source Repository branch name to trigger Cloud Build job to deploy org resources"
   default     = "main"


### PR DESCRIPTION
- Used a null_resource `git` CLI command to clone and push the policy library repo into the empty cloud source repository
- Removed the Cloud Build trigger that used to do that task
- Added a new Cloud Build trigger to `terraform apply` the ORG phase resources 