### PR TITLE
Adds support for different LZ repo names between CSR & GitHub. Updates local-exec provisioners

### DIFF
--- a/bootstrap-tutorial.md
+++ b/bootstrap-tutorial.md
@@ -238,7 +238,11 @@ cd ${HOME}/${GITHUB_REPO_NAME}
 ```
 
 ```sh
-git remote add google https://source.developers.google.com/p/${SEED_PROJ}/r/${GITHUB_REPO_NAME}
+export TF_CSR_REPO_NAME=$(terraform output -raw tf_csr_repo_name)
+```
+
+```sh
+git remote add google https://source.developers.google.com/p/${SEED_PROJ}/r/${TF_CSR_REPO_NAME}
 ```
 
 ```sh

--- a/main.tf
+++ b/main.tf
@@ -127,29 +127,17 @@ resource "google_organization_iam_member" "tf-sa-org-iam-roles" {
   ]
 }
 
-# Remove default Billing Account Creator role from the domain
+# Remove default Billing Account Creator role from the domain if present
 
 resource "null_resource" "remove-domain-billing-creator-role" {
   provisioner "local-exec" {
-    # command = "gcloud organizations remove-iam-policy-binding $ORG_ID --member=domain:$ORG_DOMAIN --role=roles/billing.creator"
-    command = <<-EOT
-      export DOMAIN_ROLE=$(gcloud organizations get-iam-policy ${ORG_ID} \
-      --flatten='bindings[].members[]' \
-      --filter='bindings.members ~ ^domain AND bindings.role=${ROLE}' \
-      --format='value(bindings.role)')
-      if [[ "${DOMAIN_ROLE}" =~ "${ROLE}"]]
-      then
-        gcloud organizations remove-iam-policy-binding ${ORG_ID} \
-        --member="domain:${ORG_DOMAIN}" \
-        --role="${ROLE}"
-      else
-        echo "Billing Account Creator role not present on domain ${ORG_DOMAIN}. Skipping deletion of this role"
-      fi
-    EOT
+    command     = "scripts/remove-domain-role.sh"
+    interpreter = ["/bin/bash", "-c"]
     environment = {
       ORG_ID     = var.org_id
       ORG_DOMAIN = var.org_domain
       ROLE       = "roles/billing.creator"
+      ROLE_NAME  = "Billing Account Creator"
     }
   }
   depends_on = [
@@ -157,29 +145,17 @@ resource "null_resource" "remove-domain-billing-creator-role" {
   ]
 }
 
-# Remove default Project Creator role from the domain
+# Remove default Project Creator role from the domain if present
 
 resource "null_resource" "remove-domain-project-creator-role" {
   provisioner "local-exec" {
-    # command = "gcloud organizations remove-iam-policy-binding $ORG_ID --member=domain:$ORG_DOMAIN --role=roles/resourcemanager.projectCreator"
-    command = <<-EOT
-      export DOMAIN_ROLE=$(gcloud organizations get-iam-policy ${ORG_ID} \
-      --flatten='bindings[].members[]' \
-      --filter='bindings.members ~ ^domain AND bindings.role=${ROLE}' \
-      --format='value(bindings.role)')
-      if [[ "${DOMAIN_ROLE}" =~ "${ROLE}"]]
-      then
-        gcloud organizations remove-iam-policy-binding ${ORG_ID} \
-        --member="domain:${ORG_DOMAIN}" \
-        --role="${ROLE}"
-      else
-        echo "Project Creator role not present on domain ${ORG_DOMAIN}. Skipping deletion of this role"
-      fi
-    EOT
+    command     = "scripts/remove-domain-role.sh"
+    interpreter = ["/bin/bash", "-c"]
     environment = {
       ORG_ID     = var.org_id
       ORG_DOMAIN = var.org_domain
       ROLE       = "roles/resourcemanager.projectCreator"
+      ROLE_NAME  = "Project Creator"
     }
   }
   depends_on = [

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,7 @@ output "tf_sa_email" {
 output "tf_sa_id" {
   value = google_service_account.tf-sa.id
 }
+
+output "tf_csr_repo_name" {
+  value = google_sourcerepo_repository.tf_lz_source.name
+}

--- a/scripts/remove-domain-role.sh
+++ b/scripts/remove-domain-role.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+# Checks for presence of specified IAM role on the provided domain
+# If the role is present then it is removed. Otherwise this step is a no-op
+
+DOMAIN_ROLE=$(gcloud organizations get-iam-policy ${ORG_ID} \
+--flatten='bindings[].members[]' \
+--filter="bindings.members ~ ^domain AND bindings.role=${ROLE}" \
+--format='value(bindings.role)')
+if [[ "${DOMAIN_ROLE}" =~ "${ROLE}" ]]
+then
+  echo "${DOMAIN_ROLE} is present on ${ORG_DOMAIN}. Removing this role..."
+  gcloud organizations remove-iam-policy-binding ${ORG_ID} \
+  --member="domain:${ORG_DOMAIN}" \
+  --role="${ROLE}"
+else
+  echo "${ROLE_NAME} role not present on domain ${ORG_DOMAIN}. Skipping deletion of this role"
+fi


### PR DESCRIPTION
- Accommodates different repo names between CSR and LZ core Terraform repo on GitHub
- Updates local-exec provisioners dealing with domain level IAM permissions to be more robust if some or all roles not present
- Adds additional shell commands to tutorial but these can be rolled into the wrapper script once merged in.