### PR TITLE
Updates Cloud Build config for Terraform Validator version v0.7.0

### DIFF
--- a/cloudbuild-builder/cloudbuild.yaml
+++ b/cloudbuild-builder/cloudbuild.yaml
@@ -13,5 +13,5 @@ steps:
 substitutions:
   _TERRAFORM_VERSION: '1.0.1' # default value
   _TERRAFORM_VERSION_SHA256SUM: 'da94657593636c8d35a96e4041136435ff58bb0061245b7d0f82db4a7728cef3' # default value
-  _TERRAFORM_VALIDATOR_RELEASE: 'v0.6.0' # default value
+  _TERRAFORM_VALIDATOR_RELEASE: 'v0.7.0' # NB: >= v0.7.0 required to support service account impersonation
 images: ['${_REPO_REGION}-docker.pkg.dev/${_REPO_PROJECT}/${_REPO_ID}/terraform']


### PR DESCRIPTION
- This change ensures that Terraform Validator `v0.7.0` is built into the Terraform container image used in subsequent Cloud Build jobs to deploy Landing Zone resources
- Version `v0.7.0` of Terraform Validator introduced support for service account impersonation which is required by the Cloud Build job configurations used in the landing zone deployment