### PR TITLE
Added billing account IAM role grant

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,15 @@ resource "google_organization_iam_member" "tf-sa-org-iam-roles" {
   ]
 }
 
+# Apply IAM roles for the Terraform service account to the billing account
+
+resource "google_billing_account_iam_member" "tf-sa-ba-iam-roles" {
+  for_each           = length(var.tf_iam_ba_roles) == 0 ? [] : toset(var.tf_iam_ba_roles)
+  billing_account_id = var.billing_account_id
+  role               = each.value
+  member             = "serviceAccount:${google_service_account.tf-sa.email}"
+}
+
 # Remove default Billing Account Creator role from the domain if present
 
 resource "null_resource" "remove-domain-billing-creator-role" {

--- a/variables.tf
+++ b/variables.tf
@@ -105,11 +105,18 @@ variable "registry_enabled_apis" {
   ]
 }
 
+variable "tf_iam_ba_roles" {
+  type        = list(string)
+  description = "List of billing account IAM roles to assign to Terraform service account"
+  default = [
+    "roles/billing.admin"
+  ]
+}
+
 variable "tf_iam_org_roles" {
   type        = list(string)
   description = "List of org level IAM roles to assign to Terraform service account"
   default = [
-    "roles/billing.user",
     "roles/cloudbuild.builds.editor",
     "roles/iam.organizationRoleAdmin",
     "roles/resourcemanager.folderAdmin",


### PR DESCRIPTION
This is the pull request for issue https://github.com/timant-dev/gcp-lz-bootstrap/issues/14
This removes the billing.user role from the org level grant and replaces it with the billing.admin role on the billing account. This allows the seed Terraform service account to grant other Terraform service accounts access to the billing account.

I have tested it by running a bootstrap deployment in a test org.