### PR TITLE
Changed Org ID, Domain and Billing Account ID to .conf input

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -144,15 +144,11 @@ function step1_generate_terraform_tfvars () {
     # Function to generate terraform.tfvars file from mandatory variables set locally and provided in conf file.
     
     # Global variables
-    ORG_ID=$(gcloud organizations list --format='value(ID)') 
-    ORG_DOMAIN=$(gcloud organizations list --format='value(displayName)') 
-    BILL_ID=$(gcloud alpha billing accounts list --format='value(ACCOUNT_ID)' --filter='OPEN=True')
-    
     printout "\n>>>>>>>>>> RUNNING: STEP #1.\n\n"
     printout "$(timestamp) [1-1]: Initialising terraform variables..."
-    if [[ (-z "${ORG_ID}") || 
-        (-z "${ORG_DOMAIN}") ||       
-        (-z "${BILL_ID}") || 
+    if [[ (-z "${ORG_ID}") ||                   # From config file
+        (-z "${ORG_DOMAIN}") ||                 # From config file
+        (-z "${BILL_ID}") ||                    # From config file
         (-z "${CLIENT_SHORT_NAME}") ||          # From config file
         (-z "${GCS_REGION}") ||                 # From config file
         (-z "${DEFAULT_REGION}") ||             # From config file

--- a/client.conf
+++ b/client.conf
@@ -1,5 +1,4 @@
 # 0. Set variables for Github landing zone repository
-
 GITHUB_BOT_USER="github-machine-user-email"
 GITHUB_BOT_NAME="github-bot-name"
 GITHUB_URL="https://github.com/"
@@ -13,3 +12,10 @@ GCS_REGION="us-east1"
 # 3. Set landing zone default region and network regions
 DEFAULT_REGION="us-east1"
 WORKLOAD_NETWORK_REGIONS="us-east1,us-east4,us-central1"
+
+# 4. Set Organization ID and Domain
+ORG_ID="123456789012"
+ORG_DOMAIN="GCP.COM"
+
+# 5. Set Billing Account ID
+BILL_ID="01AB34-5C6D78-9EFGHI"

--- a/init-tfvars.sh
+++ b/init-tfvars.sh
@@ -3,9 +3,9 @@ set -e
 
 echo "Generating Terraform tfvars file..."
 export CLIENT_SHORT_NAME=${CLIENT_NAME}
-export ORG_ID=$(gcloud organizations list --format='value(ID)')
-export ORG_DOMAIN=$(gcloud organizations list --format='value(displayName)')
-export BILL_ID=$(gcloud alpha billing accounts list --format='value(ACCOUNT_ID)' --filter='OPEN=True')
+export ORG_ID=${ORG_ID}
+export ORG_DOMAIN=${ORG_DOMAIN}
+export BILL_ID=${BILL_ID}
 export LZ_GCS_REGION=${GCS_REGION}
 export LZ_DEFAULT_REGION=${DEFAULT_REGION}
 

--- a/main.tf
+++ b/main.tf
@@ -402,11 +402,13 @@ resource "google_cloudbuild_trigger" "plan-org-phase" {
   }
   project = google_project.seed.project_id
   substitutions = {
+    _BILL_ID                  = var.billing_account_id
     _BRANCH_BASE_NAME         = var.client_short_name
     _CB_ARTEFACT_BUCKET       = "${google_storage_bucket.cloud-build-logs-artefacts.id}"
     _CLONE_TF_REPO_NAME       = var.clone_tf_csr_repo_name
     _ENABLE_CB_TRIGGERS       = true
     _GCS_REGION               = var.gcs_region
+    _ORG_ID                   = var.org_id
     _REPO_ID                  = var.artefact_registry_repo_id
     _REPO_PROJECT             = local.registry_project_unique_id
     _REPO_REGION              = var.default_region
@@ -433,11 +435,13 @@ resource "google_cloudbuild_trigger" "apply-org-phase" {
   }
   project = google_project.seed.project_id
   substitutions = {
+    _BILL_ID                  = var.billing_account_id
     _BRANCH_BASE_NAME         = var.client_short_name
     _CB_ARTEFACT_BUCKET       = "${google_storage_bucket.cloud-build-logs-artefacts.id}"
     _CLONE_TF_REPO_NAME       = var.clone_tf_csr_repo_name
     _ENABLE_CB_TRIGGERS       = true
     _GCS_REGION               = var.gcs_region
+    _ORG_ID                   = var.org_id
     _REPO_ID                  = var.artefact_registry_repo_id
     _REPO_PROJECT             = local.registry_project_unique_id
     _REPO_REGION              = var.default_region
@@ -464,11 +468,13 @@ resource "google_cloudbuild_trigger" "destroy-org-phase" {
   }
   project = google_project.seed.project_id
   substitutions = {
+    _BILL_ID                  = var.billing_account_id
     _BRANCH_BASE_NAME         = var.client_short_name
     _CB_ARTEFACT_BUCKET       = "${google_storage_bucket.cloud-build-logs-artefacts.id}"
     _CLONE_TF_REPO_NAME       = var.clone_tf_csr_repo_name
     _ENABLE_CB_TRIGGERS       = true
     _GCS_REGION               = var.gcs_region
+    _ORG_ID                   = var.org_id
     _REPO_ID                  = var.artefact_registry_repo_id
     _REPO_PROJECT             = local.registry_project_unique_id
     _REPO_REGION              = var.default_region


### PR DESCRIPTION
For issue 16

- Removed the gcloud commands from both bootstrap.sh and init-tfvars.sh for the billing account ID, organization ID and organization domain
- Added billing account ID, organization ID and organization domain examples to the client.conf file
- Tested successfully in the test organization