### PR TITLE
Adds service networking API to seed project

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,7 @@ variable "enabled_apis" {
     "iamcredentials.googleapis.com",
     "orgpolicy.googleapis.com",
     "secretmanager.googleapis.com",
+    "servicenetworking.googleapis.com",
     "serviceusage.googleapis.com",
     "sourcerepo.googleapis.com",
     "storage-api.googleapis.com",


### PR DESCRIPTION
- To support the subsequent provisioning of resources in workload environments, the seed project requires the `servicenetworking.googleapis.com` API to be enabled.